### PR TITLE
Cambiar definición de vacunas en la interfaz IPerro

### DIFF
--- a/Clase II/Clases/Perro.ts
+++ b/Clase II/Clases/Perro.ts
@@ -38,11 +38,7 @@ class Perro implements IPerro {
     private _color: string;
     private _comidasFavoritas: string[];
     private _gustaJugar: boolean;
-    private _vacunas?: {
-        rabia: boolean;
-        moquilloCanino: boolean;
-        parvo: boolean;
-    };
+    private _vacunas?: Vacunas;
     private _historialClinico: HistorialClinico;
     private _madre?: IPerro;
     private _padre?: IPerro;


### PR DESCRIPTION
Ya que se está definiendo la interfaz Vacunas, utilizarlo en el field vacunas en su definición